### PR TITLE
Add configuration options

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "ts-to-io": "./cli.js"
   },
   "dependencies": {
+    "commander": "3.0.2",
     "typescript": "3.6.3"
   },
   "devDependencies": {
-    "jest": "24.9.0",
     "@types/jest": "24.0.18",
     "@types/node": "^12.7.5",
+    "jest": "24.9.0",
     "ts-jest": "24.0.2"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,9 @@
+export interface IoToTsConfig {
+  followImports: boolean;
+  includeHeader: boolean;
+}
+
+export const defaultConfig: IoToTsConfig = {
+  followImports: false,
+  includeHeader: true
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import program from "commander";
 
 export function getCliConfig(): TsToIoConfig {
   program
+    .name("ts-to-io")
     .option(
       "--follow-imports",
       "output codecs for types declared in imported files"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,13 @@
-export interface IoToTsConfig {
+export const DEFAULT_FILE_NAME = "io-to-ts.ts";
+
+export interface TsToIoConfig {
   followImports: boolean;
   includeHeader: boolean;
+  fileNames: string[];
 }
 
-export const defaultConfig: IoToTsConfig = {
+export const defaultConfig: TsToIoConfig = {
   followImports: false,
-  includeHeader: true
+  includeHeader: true,
+  fileNames: []
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,26 @@
+import program from "commander";
+
+export function getCliConfig(): TsToIoConfig {
+  program
+    .option(
+      "--follow-imports",
+      "output codecs for types declared in imported files"
+    )
+    .option("--no-include-header", "omit io-ts import from the output")
+    .arguments("<files>");
+
+  program.parse(process.argv);
+
+  return {
+    ...program.opts(),
+    fileNames: program.args
+  } as TsToIoConfig;
+}
+
+export function displayHelp() {
+  return program.help();
+}
+
 export const DEFAULT_FILE_NAME = "io-to-ts.ts";
 
 export interface TsToIoConfig {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -114,6 +114,20 @@ describe("Generate io-ts validators", () => {
   });
 });
 
+describe("Configuration", () => {
+  test("includeHeader", () => {
+    expect(getValidatorsFromString("type a = number;", testConfig)).toBe(
+      "const a = t.number"
+    );
+    expect(
+      getValidatorsFromString("type a = number;", {
+        ...testConfig,
+        includeHeader: true
+      })
+    ).toBe('import * as t from "io-ts"\n\nconst a = t.number');
+  });
+});
+
 describe("Internals", () => {
   test("gets binary flags", () => {
     expect(extractFlags(0)).toEqual([]);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,15 +1,22 @@
 import { getValidatorsFromString } from ".";
 import { extractFlags } from "./flags";
+import { defaultConfig, DEFAULT_FILE_NAME } from "./config";
+
+const testConfig = {
+  ...defaultConfig,
+  fileNames: [DEFAULT_FILE_NAME],
+  includeHeader: false
+};
 
 describe("Generate io-ts validators", () => {
   test("generates validators for primitive types", () => {
-    expect(getValidatorsFromString("type num = number;")).toBe(
+    expect(getValidatorsFromString("type num = number;", testConfig)).toBe(
       "const num = t.number"
     );
-    expect(getValidatorsFromString("type str = string;")).toBe(
+    expect(getValidatorsFromString("type str = string;", testConfig)).toBe(
       "const str = t.string"
     );
-    expect(getValidatorsFromString("type nil = null;")).toBe(
+    expect(getValidatorsFromString("type nil = null;", testConfig)).toBe(
       "const nil = t.null"
     );
   });
@@ -23,39 +30,42 @@ describe("Generate io-ts validators", () => {
   `;
     const result = "const Test = t.type({foo: t.number, bar: t.string})";
 
-    expect(getValidatorsFromString(inputInterface)).toBe(result);
-    expect(getValidatorsFromString(inputObjectType)).toBe(result);
+    expect(getValidatorsFromString(inputInterface, testConfig)).toBe(result);
+    expect(getValidatorsFromString(inputObjectType, testConfig)).toBe(result);
   });
 
   test("generates validators for arrays", () => {
-    expect(getValidatorsFromString("type arr = string[]")).toBe(
+    expect(getValidatorsFromString("type arr = string[]", testConfig)).toBe(
       "const arr = t.array(t.string)"
     );
-    expect(getValidatorsFromString("type arr = Array<{foo: string}>")).toBe(
-      "const arr = t.array(t.type({foo: t.string}))"
-    );
+    expect(
+      getValidatorsFromString("type arr = Array<{foo: string}>", testConfig)
+    ).toBe("const arr = t.array(t.type({foo: t.string}))");
   });
 
   test("generates validators for record types", () => {
-    expect(getValidatorsFromString("type rec = Record<number, string>")).toBe(
-      "const rec = t.record(t.number, t.string)"
-    );
-    expect(getValidatorsFromString("type rec = Record<string, null>")).toBe(
-      "const rec = t.record(t.string, t.null)"
-    );
+    expect(
+      getValidatorsFromString("type rec = Record<number, string>", testConfig)
+    ).toBe("const rec = t.record(t.number, t.string)");
+    expect(
+      getValidatorsFromString("type rec = Record<string, null>", testConfig)
+    ).toBe("const rec = t.record(t.string, t.null)");
   });
 
   test("generates validators for union types", () => {
-    expect(getValidatorsFromString("type un = string | number")).toBe(
-      "const un = t.union([t.string, t.number])"
-    );
     expect(
-      getValidatorsFromString("type un = string | number | { foo: string }")
+      getValidatorsFromString("type un = string | number", testConfig)
+    ).toBe("const un = t.union([t.string, t.number])");
+    expect(
+      getValidatorsFromString(
+        "type un = string | number | { foo: string }",
+        testConfig
+      )
     ).toBe("const un = t.union([t.string, t.number, t.type({foo: t.string})])");
   });
 
   test("optimizes validator for string literal union types", () => {
-    expect(getValidatorsFromString("type un = 'foo' | 'bar'")).toBe(
+    expect(getValidatorsFromString("type un = 'foo' | 'bar'", testConfig)).toBe(
       'const un = t.keyof({"foo": null, "bar": null})'
     );
   });
@@ -63,7 +73,8 @@ describe("Generate io-ts validators", () => {
   test("generates validators for intersection types", () => {
     expect(
       getValidatorsFromString(
-        "type inter = { foo: string } | { bar: number } | { foo: number }"
+        "type inter = { foo: string } | { bar: number } | { foo: number }",
+        testConfig
       )
     ).toBe(
       "const inter = t.union([t.type({foo: t.string}), t.type({bar: t.number}), t.type({foo: t.number})])"
@@ -71,30 +82,33 @@ describe("Generate io-ts validators", () => {
   });
 
   test("generates validators for function types", () => {
-    expect(getValidatorsFromString("type fn = () => void")).toBe(
+    expect(getValidatorsFromString("type fn = () => void", testConfig)).toBe(
       "const fn = t.Function"
     );
     expect(
       getValidatorsFromString(
-        "type fn = (s: string, n: number) => (b: boolean) => object"
+        "type fn = (s: string, n: number) => (b: boolean) => object",
+        testConfig
       )
     ).toBe("const fn = t.Function");
   });
 
   test("generates validators for literal types", () => {
-    expect(getValidatorsFromString('type foo = "foo"')).toBe(
+    expect(getValidatorsFromString('type foo = "foo"', testConfig)).toBe(
       'const foo = t.literal("foo")'
     );
-    expect(getValidatorsFromString("type one = 1")).toBe(
+    expect(getValidatorsFromString("type one = 1", testConfig)).toBe(
       "const one = t.literal(1)"
     );
-    expect(getValidatorsFromString("type f = false")).toBe(
+    expect(getValidatorsFromString("type f = false", testConfig)).toBe(
       "const f = t.literal(false)"
     );
   });
 
   test("handles nullable types correctly", () => {
-    expect(getValidatorsFromString('type foobar = "foo" | "bar" | null')).toBe(
+    expect(
+      getValidatorsFromString('type foobar = "foo" | "bar" | null', testConfig)
+    ).toBe(
       'const foobar = t.union([t.null, t.literal("foo"), t.literal("bar")])'
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ export function getValidatorsFromString(
     compilerHostOptions
   );
   const checker = program.getTypeChecker();
-  const result: string[] = [];
+  const result = config.includeHeader ? [getImports()] : [];
   ts.forEachChild(
     program.getSourceFile(DEFAULT_FILE_NAME)!,
     visit(checker, config, result)
@@ -215,7 +215,7 @@ export function getValidatorsFromFileNames(
 ) {
   const program = ts.createProgram(files, compilerOptions);
   const checker = program.getTypeChecker();
-  const result = [getImports()];
+  const result = config.includeHeader ? [getImports()] : [];
   for (const sourceFile of program.getSourceFiles()) {
     if (!sourceFile.isDeclarationFile) {
       ts.forEachChild(sourceFile, visit(checker, config, result));

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,13 @@ import {
   isLiteralType
 } from "./type";
 import { extractFlags } from "./flags";
-import { defaultConfig, TsToIoConfig, DEFAULT_FILE_NAME } from "./config";
+import {
+  defaultConfig,
+  TsToIoConfig,
+  DEFAULT_FILE_NAME,
+  getCliConfig,
+  displayHelp
+} from "./config";
 
 const processProperty = (checker: ts.TypeChecker) => (s: ts.Symbol) => {
   return `${s.name}: ${processType(checker)(
@@ -209,11 +215,8 @@ export function getValidatorsFromString(
   return result.join("\n\n");
 }
 
-export function getValidatorsFromFileNames(
-  files: string[],
-  config = { ...defaultConfig, fileNames: files }
-) {
-  const program = ts.createProgram(files, compilerOptions);
+export function getValidatorsFromFileNames(config: TsToIoConfig) {
+  const program = ts.createProgram(config.fileNames, compilerOptions);
   const checker = program.getTypeChecker();
   const result = config.includeHeader ? [getImports()] : [];
   for (const sourceFile of program.getSourceFiles()) {
@@ -229,5 +232,10 @@ function isEntryPoint() {
 }
 
 if (isEntryPoint()) {
-  console.log(getValidatorsFromFileNames([process.argv[2]]));
+  const config = getCliConfig();
+  if (!config.fileNames.length) {
+    displayHelp();
+  } else {
+    console.log(getValidatorsFromFileNames(config));
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   isLiteralType
 } from "./type";
 import { extractFlags } from "./flags";
+import { defaultConfig } from "./config";
 
 const processProperty = (checker: ts.TypeChecker) => (s: ts.Symbol) => {
   return `${s.name}: ${processType(checker)(
@@ -115,6 +116,7 @@ function handleTypeDeclaration(
 ) {
   try {
     const symbol = checker.getSymbolAtLocation(node.name);
+    console.log(node.getSourceFile().fileName);
     const type = checker.getTypeAtLocation(node);
     result.push(`const ${symbol!.name} = ` + processType(checker)(type));
   } catch (e) {
@@ -145,6 +147,8 @@ function handleVariableDeclaration(
     const symbol = checker.getSymbolAtLocation(
       node.declarationList.declarations[0].name
     );
+    console.log(node.getSourceFile().fileName);
+
     const type = checker.getTypeOfSymbolAtLocation(
       symbol!,
       symbol!.valueDeclaration!
@@ -179,7 +183,10 @@ const compilerOptions: ts.CompilerOptions = {
   strictNullChecks: true
 };
 
-export function getValidatorsFromString(source: string) {
+export function getValidatorsFromString(
+  source: string,
+  config = defaultConfig
+) {
   const DEFAULT_FILE_NAME = "io-to-ts.ts";
   const defaultCompilerHostOptions = ts.createCompilerHost({});
 
@@ -220,7 +227,10 @@ export function getValidatorsFromString(source: string) {
   return result.join("\n\n");
 }
 
-export function getValidatorsFromFileNames(files: string[]) {
+export function getValidatorsFromFileNames(
+  files: string[],
+  config = defaultConfig
+) {
   const program = ts.createProgram(files, compilerOptions);
   const checker = program.getTypeChecker();
   const result = [getImports()];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "declaration": true,
     "outDir": "build",
     "sourceMap": true,
-    "strict": true
+    "strict": true,
+    "esModuleInterop": true
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,6 +777,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
+  integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
+
 commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"


### PR DESCRIPTION
Adds the following config options

- `followImports` / `--follow-imports`:      output codecs for types declared in imported files
- `includeHeader` /  `no-include-header`: include/omit io-ts import from the output.

Additionally improves the CLI by adding the `--help` command.