### PR TITLE
Fix CLI arg handling

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,4 +2,4 @@
 
 var tsToIo = require("./build/index.js");
 
-console.log(tsToIo.getValidatorsFromFileNames([process.argv[2]]));
+console.log(tsToIo.getValidatorsFromFileNames());

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "start": "node build/index.js",
+    "start": "./cli.js",
     "test": "jest"
   },
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,11 @@ export function getValidatorsFromString(
   return result.join("\n\n");
 }
 
-export function getValidatorsFromFileNames(config: TsToIoConfig) {
+export function getValidatorsFromFileNames() {
+  const config = getCliConfig();
+  if (!config.fileNames.length) {
+    return displayHelp();
+  }
   const program = ts.createProgram(config.fileNames, compilerOptions);
   const checker = program.getTypeChecker();
   const result = config.includeHeader ? [getImports()] : [];
@@ -225,17 +229,4 @@ export function getValidatorsFromFileNames(config: TsToIoConfig) {
     }
   }
   return result.join("\n\n");
-}
-
-function isEntryPoint() {
-  return require.main === module;
-}
-
-if (isEntryPoint()) {
-  const config = getCliConfig();
-  if (!config.fileNames.length) {
-    displayHelp();
-  } else {
-    console.log(getValidatorsFromFileNames(config));
-  }
 }


### PR DESCRIPTION
Fixes a bug in 0.2.0 when using a CLI. Additionally, usage from `start` script and CLI is now the same.