### PR TITLE
feature: improve the error indicating comment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ function handleDeclaration(
     }
     return `const ${symbol!.name} = ` + processType(checker)(type);
   } catch (e) {
-    return "// Error: Failed to generate a codec";
+    return `// Error: Failed to generate a codec for ${symbol ? symbol.name : ''}`;
   }
 }
 


### PR DESCRIPTION
For a noob like me an error comment without any details
creates confusion. This commit adds the name of the
offending type to the comment.